### PR TITLE
Add SoloLuck (Jakarta, Indonesia) — first Southeast Asia stratum endpoint

### DIFF
--- a/stratum_test.py
+++ b/stratum_test.py
@@ -77,10 +77,10 @@ from statistics import mean, median
 #   5. location (str): Country code (ISO 3166-1 alpha-2) or "*MANY*" for Anycast
 #
 # Location codes: AU=Australia, CH=Switzerland, DE=Germany, FR=France, NL=Netherlands,
-#                 RU=Russia, SG=Singapore, UK=United Kingdom, US=United States, *MANY*=Anycast (multiple locations)
+#                 ID=Indonesia, RU=Russia, UK=United Kingdom, US=United States, *MANY*=Anycast (multiple locations)
 PREDEFINED_SERVERS = [
     ("solo.atlaspool.io", 3333, 4333, "AtlasPool.io", "*MANY*"),  # Anycast - Global edge network
-    ("stratum.sololuck.io", 3333, 3334, "SoloLuck", "SG"),  # Singapore/Jakarta - true-solo, lowest latency for SE Asia
+    ("stratum.sololuck.io", 3333, 3334, "SoloLuck", "ID"),  # Jakarta, Indonesia - true-solo, lowest latency for SE Asia
     ("ausolo.ckpool.org", 3333, 0, "AU CKPool", "AU"),      # Australia
     ("stratum.kano.is", 3333, 0, "KanoPool", "US"),          # United States
     ("eusolo.ckpool.org", 3333, 0, "EU CKPool", "DE"),      # Germany

--- a/stratum_test.py
+++ b/stratum_test.py
@@ -77,9 +77,10 @@ from statistics import mean, median
 #   5. location (str): Country code (ISO 3166-1 alpha-2) or "*MANY*" for Anycast
 #
 # Location codes: AU=Australia, CH=Switzerland, DE=Germany, FR=France, NL=Netherlands,
-#                 RU=Russia, UK=United Kingdom, US=United States, *MANY*=Anycast (multiple locations)
+#                 RU=Russia, SG=Singapore, UK=United Kingdom, US=United States, *MANY*=Anycast (multiple locations)
 PREDEFINED_SERVERS = [
     ("solo.atlaspool.io", 3333, 4333, "AtlasPool.io", "*MANY*"),  # Anycast - Global edge network
+    ("stratum.sololuck.io", 3333, 3334, "SoloLuck", "SG"),  # Singapore/Jakarta - true-solo, lowest latency for SE Asia
     ("ausolo.ckpool.org", 3333, 0, "AU CKPool", "AU"),      # Australia
     ("stratum.kano.is", 3333, 0, "KanoPool", "US"),          # United States
     ("eusolo.ckpool.org", 3333, 0, "EU CKPool", "DE"),      # Germany


### PR DESCRIPTION
The predefined server list currently has no Southeast Asia entry (only AtlasPool's anycast and AU CKPool), so SE-Asian solo miners can't benchmark a nearby pool from this tool.

This adds **SoloLuck** — a true-solo (`ckpool -B`), non-custodial pool hosted in Jakarta, Indonesia:

```python
("stratum.sololuck.io", 3333, 3334, "SoloLuck", "ID"),
```

- Stratum: `stratum.sololuck.io:3333` (also :8081, :4334, :3335 tiers)
- TLS: `:3334` — the LE cert's SAN covers `stratum.sololuck.io`, so the tool's TLS test validates
- Also adds `ID=Indonesia` to the location-code legend

For context, from a residential connection in Indonesia I measure ~6 ms to this endpoint vs ~250 ms to the US-hosted solo pools, so it fills a real gap in the list's regional coverage. Single-line data addition; no code changes.